### PR TITLE
create the Jenkins components within a VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,20 @@ To create the Jenkins infrastructure, include the [Terraform modules](https://ww
 # optional - use if you want a Jenkins-specific security group
 module "jenkins_networking" {
   source = "./<path_to_ansible_role>/terraform/modules/networking"
+
+  vpc_id = "${<vpc_id>}"
 }
 
 module "jenkins_instances" {
   source = "./<path_to_ansible_role>/terraform/modules/instances"
+
+  subnet_id = "${<subnet_id}"
   # you can pass in a different security group name instead
-  security_groups = ["${module.jenkins_networking.sg_name}"]
+  vpc_security_group_ids = ["${module.jenkins_networking.sg_id}"]
 }
 ```
 
-See the variables files in the [`networking`](terraform/modules/networking/vars.tf) and [`instances`](terraform/modules/instances/vars.tf) modules for more options. [Overrides](https://www.terraform.io/docs/configuration/override.html) can also be used for greater customization.
+See the variables files in the [`networking`](terraform/modules/networking/vars.tf) and [`instances`](terraform/modules/instances/vars.tf) modules for more options. See the [example usage](terraform/aws.tf).
 
 ### Ansible role
 

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -2,12 +2,29 @@ provider "aws" {
   region = "${var.region}"
 }
 
+data "aws_region" "current" {
+  current = true
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
 module "networking" {
   source = "./modules/networking"
+
+  vpc_id = "${data.aws_vpc.default.id}"
 }
 
 module "instances" {
   source = "./modules/instances"
+
   key_name = "${var.key_name}"
-  security_groups = ["${module.networking.sg_name}"]
+  # pick first subnet in default VPC, arbitrarily
+  subnet_id = "${element(data.aws_subnet_ids.all.ids, 0)}"
+  vpc_security_group_ids = ["${module.networking.sg_id}"]
 }

--- a/terraform/modules/instances/master.tf
+++ b/terraform/modules/instances/master.tf
@@ -1,9 +1,10 @@
 resource "aws_instance" "jenkins" {
   instance_type = "${var.instance_type}"
-  # security_groups = ["${aws_security_group.sg_jenkins.name}"]
-  security_groups = ["${var.security_groups}"]
   ami = "${var.ami}"
   key_name = "${var.key_name}"
+
+  subnet_id = "${var.subnet_id}"
+  vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
 
   # The connection block tells our provisioner how to
   # communicate with the resource (instance)

--- a/terraform/modules/instances/vars.tf
+++ b/terraform/modules/instances/vars.tf
@@ -13,8 +13,12 @@ variable "instance_type" {
   default = "t2.micro"
 }
 
-variable "security_groups" {
+# networking
+variable "vpc_security_group_ids" {
   type = "list"
+}
+variable "subnet_id" {
+  type = "string"
 }
 
 variable "key_name" {

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -1,3 +1,3 @@
-output "sg_name" {
-  value = "${aws_security_group.sg_jenkins.name}"
+output "sg_id" {
+  value = "${aws_security_group.sg_jenkins.id}"
 }

--- a/terraform/modules/networking/security_group.tf
+++ b/terraform/modules/networking/security_group.tf
@@ -2,6 +2,8 @@ resource "aws_security_group" "sg_jenkins" {
   name = "${var.sg_name}"
   description = "Allows all traffic"
 
+  vpc_id = "${var.vpc_id}"
+
   # SSH
   ingress {
     from_port = 22

--- a/terraform/modules/networking/vars.tf
+++ b/terraform/modules/networking/vars.tf
@@ -1,3 +1,7 @@
+variable "vpc_id" {
+  type = "string"
+}
+
 variable "sg_name" {
   default = "sg_jenkins"
   description = "Security group name"


### PR DESCRIPTION
Before, the security group and instances weren't being created within a VPC, which was an oversight (I didn't realize this is how AWS works). GSA are almost definitely using VPCs for servers, so might as well include the appropriate configuration variables.