### PR TITLE
provide the Jenkins master's private IP as an output

### DIFF
--- a/terraform/modules/instances/outputs.tf
+++ b/terraform/modules/instances/outputs.tf
@@ -1,3 +1,7 @@
 output "public_ip" {
   value = "${aws_instance.jenkins.public_ip}"
 }
+
+output "private_ip" {
+  value = "${aws_instance.jenkins.private_ip}"
+}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,7 +7,7 @@
     - set_fact:
         jenkins_external_hostname: "{{ inventory_hostname }}"
   roles:
-    # needs to match repository name
+    # needs to match repository name; when the role is included normally, it will be `gsa.jenkins`
     - jenkins-deploy
   tasks:
 


### PR DESCRIPTION
This will be needed when the subnet doesn't assign a public IP by default.