### PR TITLE
make the server names configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,10 @@
 # need to specify both here and in `meta/main.yml`, due to https://github.com/ansible/ansible/issues/17678
 ssl_certs_common_name: "{{ jenkins_external_hostname }}"
 
+# a space-delimited list of server names that nginx should respond to
+# https://nginx.org/en/docs/http/server_names.html
+server_names: "{{ jenkins_external_hostname }}"
+
 
 ### Plugins ###
 

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -28,7 +28,7 @@
   fail:
   when: http_req.location != 'https://localhost/'
 
-- name: Check Jenkins responds via HTTPS
+- name: Check nginx responds via HTTPS
   uri:
     url: https://localhost
     follow_redirects: none

--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -2,13 +2,13 @@
 
 server {
   listen 80;
-  server_name {{ jenkins_external_hostname }};
+  server_name {{ server_names }};
   return 301 https://$host$request_uri;
 }
 
 server {
   listen 443 ssl;
-  server_name {{ jenkins_external_hostname }};
+  server_name {{ server_names }};
 
   ssl_certificate {{ ssl_certs_cert_path }};
   ssl_certificate_key {{ ssl_certs_privkey_path }};


### PR DESCRIPTION
Being able to override this default is useful for debugging, such as ensuring that nginx is working, prior to the DNS being in place.