### PR TITLE
set up SSH key for Jenkins to use in Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ See [`defaults/main.yml`](defaults/main.yml).
 
     ```sh
     ssh-keygen -t rsa -b 4096 -f temp.key -C "group-email+jenkins@some.gov"
-    # enter a passphrase
+    # enter a passphrase - store in Vault as vault_jenkins_ssh_key_passphrase
 
     cat temp.key
-    # store in Vault as jenkins_ssh_private_key_data
+    # store in Vault as vault_jenkins_ssh_private_key_data
 
     cat temp.key.pub
-    # store in Vault as jenkins_ssh_public_key_data
+    # store as jenkins_ssh_public_key_data
 
     rm temp.key*
     ```
@@ -119,6 +119,11 @@ See [`defaults/main.yml`](defaults/main.yml).
     ssl_certs_local_privkey_data: "{{ vault_ssl_certs_local_privkey_data }}"
 
     # group_vars/jenkins/vault.yml (encrypted)
+    vault_jenkins_ssh_key_passphrase: ...
+    vault_jenkins_ssh_private_key_data: |
+      -----BEGIN RSA PRIVATE KEY-----
+      ...
+      -----END RSA PRIVATE KEY-----
     vault_ssl_certs_local_cert_data: |
       -----BEGIN CERTIFICATE-----
       ...
@@ -143,7 +148,7 @@ See [`defaults/main.yml`](defaults/main.yml).
           user:
             name: "{{ jenkins_ssh_user }}"
             group: wheel
-        - name: Create Jenkins user
+        - name: Set up SSH key for Jenkins
           authorized_key:
             user: "{{ jenkins_ssh_user }}"
             key: "{{ jenkins_ssh_public_key_data }}"
@@ -159,7 +164,7 @@ See [`defaults/main.yml`](defaults/main.yml).
         1. `Scope`: `Global (Jenkins, nodes, items, all child items, etc)`
         1. `Username`: `jenkins`
         1. `Private Key`: `From the Jenkins master ~/.ssh`
-        1. `Passphrase`: (empty)
+        1. `Passphrase`: the value from `vault_jenkins_ssh_key_passphrase`
         1. `ID`: `jenkins-ssh-key`
         1. `Description`: (empty)
     1. Click `OK`.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ See [`defaults/main.yml`](defaults/main.yml). Required variables:
     - gsa.jenkins
 ```
 
+#### Manual configuration
+
+The Ansible role will generate an SSH key for Jenkins to use when provisioning. You will need to Add Credentials in Jenkins manually.
+
+1. Visit https://JENKINS_URL/credentials/store/system/domain/_/newCredentials
+1. Fill in the form:
+    1. `Kind`: `SSH Username with private key`
+    1. `Scope`: `Global (Jenkins, nodes, items, all child items, etc)`
+    1. `Username`: `jenkins`
+    1. `Private Key`: `From the Jenkins master ~/.ssh`
+    1. `Passphrase`: (empty)
+    1. `ID`: `jenkins-ssh-key`
+    1. `Description`: (empty)
+1. Click `OK`.
+
+You can then use these Credentials from your Jobs.
+
 ## Development
 
 To test locally:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ ssl_certs_common_name: "{{ jenkins_external_hostname }}"
 # https://nginx.org/en/docs/http/server_names.html
 server_names: "{{ jenkins_external_hostname }}"
 
+jenkins_ssh_user: jenkins
 
 ### Plugins ###
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,3 +44,9 @@
   when: "'Jenkins' not in jenkins_req.content"
 
 - include: nginx.yml
+
+- name: Generate SSH key
+  user:
+    name: jenkins
+    generate_ssh_key: yes
+    ssh_key_bits: 4096

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,9 +44,4 @@
   when: "'Jenkins' not in jenkins_req.content"
 
 - include: nginx.yml
-
-- name: Generate SSH key
-  user:
-    name: jenkins
-    generate_ssh_key: yes
-    ssh_key_bits: 4096
+- include: ssh.yml

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -1,0 +1,24 @@
+---
+- name: Create SSH directory
+  file:
+    path: "{{ jenkins_home }}/.ssh"
+    state: directory
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    mode: 0700
+
+- name: Write private SSH key
+  copy:
+    content: "{{ jenkins_ssh_private_key_data }}"
+    dest: "{{ jenkins_home }}/.ssh/id_rsa"
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    mode: 0600
+
+- name: Write public SSH key
+  copy:
+    content: "{{ jenkins_ssh_public_key_data }}"
+    dest: "{{ jenkins_home }}/.ssh/id_rsa.pub"
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    mode: 0644

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+---
+jenkins_user: jenkins
+jenkins_group: jenkins


### PR DESCRIPTION
This pull request instructs the user of this role to set up an SSH key for Jenkins, for use when, for example, running Ansible against target machines. They will add the private key to the repository via the Ansible Vault, so that if the Jenkins instance is terminated, the private key won't be lost.