### PR TITLE
fix Ansible connection to Jenkins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # need to specify both here and in `meta/main.yml`, due to https://github.com/ansible/ansible/issues/17678
 ssl_certs_common_name: "{{ jenkins_external_hostname }}"
 
+# the homepage may not be accessible if anonymous users don't have read permissions, so check the login page
+jenkins_health_check_path: /login
 # a space-delimited list of server names that nginx should respond to
 # https://nginx.org/en/docs/http/server_names.html
 server_names: "{{ jenkins_external_hostname }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
 # http://stackoverflow.com/a/34522653/358804
 - name: Wait for Jenkins to be available
   uri:
-    url: http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}
+    url: http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}{{ jenkins_health_check_path }}
     return_content: true
   register: jenkins_req
   until: jenkins_req.status == 200

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
     params:
       url_username: "{{ jenkins_admin_username }}"
       url_password: "{{ jenkins_admin_password }}"
-    url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
+    url: http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}
   with_items: "{{ jenkins_plugins + additional_jenkins_plugins }}"
   notify: restart jenkins
 
@@ -32,7 +32,7 @@
 # http://stackoverflow.com/a/34522653/358804
 - name: Wait for Jenkins to be available
   uri:
-    url: http://{{ jenkins_hostname }}:{{ jenkins_http_port }}
+    url: http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}
     return_content: true
   register: jenkins_req
   until: jenkins_req.status == 200

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -20,17 +20,17 @@
 
 - name: Check nginx redirects HTTP to HTTPS
   uri:
-    url: http://localhost
+    url: http://{{ jenkins_hostname }}{{ jenkins_url_prefix }}
     follow_redirects: none
     status_code: 301
   register: http_req
 - name: Fail if HTTP doesn't redirect to HTTPS
   fail:
-  when: http_req.location != 'https://localhost/'
+  when: not http_req.location.startswith('https://' + jenkins_hostname)
 
 - name: Check nginx responds via HTTPS
   uri:
-    url: https://localhost
+    url: https://localhost{{ jenkins_url_prefix }}
     follow_redirects: none
     return_content: yes
     # TODO have it use the test cert

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -20,7 +20,7 @@
 
 - name: Check nginx redirects HTTP to HTTPS
   uri:
-    url: http://{{ jenkins_hostname }}{{ jenkins_url_prefix }}
+    url: http://{{ jenkins_hostname }}{{ jenkins_url_prefix }}{{ jenkins_health_check_path }}
     follow_redirects: none
     status_code: 301
   register: http_req

--- a/tests/group_vars/all/ssh.yml
+++ b/tests/group_vars/all/ssh.yml
@@ -1,0 +1,3 @@
+---
+jenkins_ssh_private_key_data: DUMMY_KEY
+jenkins_ssh_public_key_data: DUMMY_KEY


### PR DESCRIPTION
This pull request fixes a few semi-related issues:

* Constructs the Jenkins URL more consistently throughout the code
* Makes the health check path configurable, since the homepage may not be accessible for anonymous users (as is the case for D2D, as of https://github.com/GSA/d2d/pull/439)
* Provide a dummy SSH key for testing the role