### PR TITLE
add missing use of jenkins_health_check_path

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -30,7 +30,7 @@
 
 - name: Check nginx responds via HTTPS
   uri:
-    url: https://localhost{{ jenkins_url_prefix }}
+    url: https://localhost{{ jenkins_url_prefix }}{{ jenkins_health_check_path }}
     follow_redirects: none
     return_content: yes
     # TODO have it use the test cert

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -3,22 +3,22 @@
   file:
     path: "{{ jenkins_home }}/.ssh"
     state: directory
-    owner: "{{ jenkins_user }}"
-    group: "{{ jenkins_group }}"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
     mode: 0700
 
 - name: Write private SSH key
   copy:
     content: "{{ jenkins_ssh_private_key_data }}"
     dest: "{{ jenkins_home }}/.ssh/id_rsa"
-    owner: "{{ jenkins_user }}"
-    group: "{{ jenkins_group }}"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
     mode: 0600
 
 - name: Write public SSH key
   copy:
     content: "{{ jenkins_ssh_public_key_data }}"
     dest: "{{ jenkins_home }}/.ssh/id_rsa.pub"
-    owner: "{{ jenkins_user }}"
-    group: "{{ jenkins_group }}"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
     mode: 0644

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,0 @@
----
-jenkins_user: jenkins
-jenkins_group: jenkins


### PR DESCRIPTION
Follow-up to #42.

Also switched from using a custom-defined Jenkins machine user/group, to inheriting the one from geerlingguy.jenkins.