### PR TITLE
make nginx config file path backwards-compatible

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -58,3 +58,5 @@ dependencies:
     name: gsa.ansible-https-proxy
     external_hostname: "{{ jenkins_external_hostname }}"
     upstream_origin: "{{ jenkins_hostname }}:{{ jenkins_http_port }}"
+    # for backwards compatability, prior to https://github.com/GSA/jenkins-deploy/pull/36
+    nginx_proxy_vhost_path: "{{ nginx_vhost_path }}/jenkins.conf"


### PR DESCRIPTION
Corresponds to https://github.com/GSA/ansible-https-proxy/pull/18.